### PR TITLE
Fixes typo in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Harry Roberts <harry@csswizardry.com>"
   ],
   "description": "Responsive tooling for the inuitcss framework",
-  "main": "_settings.responsive.scss",
+  "main": "_tools.responsive.scss",
   "keywords": [
     "css",
     "oocss",


### PR DESCRIPTION
Automated tools (like `grunt-bower-install`) fail to discover the main file as the `main` member points to a file that doesn't exist.
