### PR TITLE
Simplifying media-query mixin

### DIFF
--- a/_tools.responsive.scss
+++ b/_tools.responsive.scss
@@ -42,6 +42,6 @@ $inuit-responsive-settings: false !default;
   }
 
   @else {
-    @warn "Oops! Breakpoint ‘#{$breakpoint-name}’ does not exist."
+    @warn "Oops! Breakpoint ‘#{$mq}’ does not exist."
   }
 }

--- a/_tools.responsive.scss
+++ b/_tools.responsive.scss
@@ -31,34 +31,17 @@ $inuit-responsive-settings: false !default;
 
 @mixin media-query($mq) {
 
-    $breakpoint-found: false;
+  // Check if the key is in our breakpoint list
+  @if map-has-key($breakpoints, $mq) {
 
-    // Loop through the list of breakpoints we’ve provided in our settings file.
-    @each $breakpoint in $breakpoints {
-
-        // Grab the alias and the condition from their respective locations in
-        // the list.
-        $alias:     nth($breakpoint, 1);
-        $condition: nth($breakpoint, 2);
-
-        // If the media query we’ve specified has an alias and a condition...
-        @if $mq == $alias and $condition {
-
-            // ...tell the mixin that we’ve found it...
-            $breakpoint-found: true;
-
-            // ...and spit it out here.
-            @media #{$condition} {
-                @content;
-            }
-
-        }
-
+    // Get the key value and output the code
+    @media #{map-get($breakpoints, $mq)} {
+      @content;
     }
 
-    // If the user specifies a non-exitent alias, send them a warning.
-    @if $breakpoint-found == false{
-        @warn "Oops! Breakpoint ‘#{$mq}’ does not exist."
-    }
+  }
 
+  @else {
+    @warn "Oops! Breakpoint ‘#{$breakpoint-name}’ does not exist."
+  }
 }


### PR DESCRIPTION
By using the map functions there are no need to iterate over the list each time you use the media-query mixin.
